### PR TITLE
Contact component

### DIFF
--- a/components/digital-agency/Contact.css
+++ b/components/digital-agency/Contact.css
@@ -1,0 +1,28 @@
+:root {
+  --brand-color-red: #fc2847;
+  --color-regular: #fff;
+
+  --contact-btn: var(--brand-color-red);
+}
+
+.contact-btn {
+  font-size: 15px;
+  font-weight: 500;
+  position: relative;
+  z-index: 1;
+  padding: 14px 33px;
+  color: var(--color-regular);
+  border-radius: 25px;
+  background: var(--contact-btn);
+  opacity: .8
+}
+
+.contact-btn:hover {
+  color: var(--color-regular);
+  background: var(--contact-btn);
+  opacity: 1;
+}
+
+.contact-btn:visited {
+  color: var(--color-regular);
+}

--- a/components/digital-agency/Contact.js
+++ b/components/digital-agency/Contact.js
@@ -3,34 +3,30 @@ import React, { Component } from "react";
 import "./Contact.css";
 
 const EMAIL = "info@deadlyconnections.org.au";
-export class Contact extends Component {
-  render() {
-    return (
-      <section className="contact-cta-area ptb-120">
-        <div className="container">
-          <div className="contact-cta-content">
-            <div className="section-title">
-              <span>Get in Touch</span>
-              <h2>We're here to help</h2>
-            </div>
 
-            <p>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-              eiusmod tempor incididunt ut labore et dolore magna aliqua. Quis
-              ipsum suspendisse ultrices gravida. Risus commodo viverra maecenas
-              accumsan lacus vel facilisis.
-            </p>
-            <a
-              className="contact-btn"
-              href={`mailto:${EMAIL}?Subject=Website enquiry`}
-            >
-              Contact Us
-            </a>
-          </div>
+const Contact = () => (
+  <section className="contact-cta-area ptb-120">
+    <div className="container">
+      <div className="contact-cta-content">
+        <div className="section-title">
+          <span>Get in Touch</span>
+          <h2>We're here to help</h2>
         </div>
-      </section>
-    );
-  }
-}
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Quis ipsum
+          suspendisse ultrices gravida. Risus commodo viverra maecenas accumsan
+          lacus vel facilisis.
+        </p>
+        <a
+          className="contact-btn"
+          href={`mailto:${EMAIL}?Subject=Website enquiry`}
+        >
+          Contact Us
+        </a>
+      </div>
+    </div>
+  </section>
+);
 
 export default Contact;

--- a/components/digital-agency/Contact.js
+++ b/components/digital-agency/Contact.js
@@ -1,26 +1,36 @@
-import React, { Component } from 'react';
-import Link from 'next/link';
+import React, { Component } from "react";
 
+import "./Contact.css";
+
+const EMAIL = "info@deadlyconnections.org.au";
 export class Contact extends Component {
-    render() {
-        return (
-            <section className="contact-cta-area ptb-120">
-                <div className="container">
-                    <div className="contact-cta-content">
-                        <div className="section-title">
-                            <span>Get in Touch</span>
-                            <h2>Want to work with us? Let's talk about project!</h2>
-                        </div>
+  render() {
+    return (
+      <section className="contact-cta-area ptb-120">
+        <div className="container">
+          <div className="contact-cta-content">
+            <div className="section-title">
+              <span>Get in Touch</span>
+              <h2>We're here to help</h2>
+            </div>
 
-                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Quis ipsum suspendisse ultrices gravida. Risus commodo viverra maecenas accumsan lacus vel facilisis.</p>
-                        <Link href="#">
-                            <a className="btn btn-primary">Contact Us</a>
-                        </Link>
-                    </div>
-                </div>
-            </section>
-        );
-    }
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Quis
+              ipsum suspendisse ultrices gravida. Risus commodo viverra maecenas
+              accumsan lacus vel facilisis.
+            </p>
+            <a
+              className="contact-btn"
+              href={`mailto:${EMAIL}?Subject=Website enquiry`}
+            >
+              Contact Us
+            </a>
+          </div>
+        </div>
+      </section>
+    );
+  }
 }
 
 export default Contact;

--- a/components/digital-agency/Contact.js
+++ b/components/digital-agency/Contact.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 
 import "./Contact.css";
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -15,7 +15,7 @@ import Team from "../components/digital-agency/Team";
 // import Funfacts from "../components/digital-agency/Funfacts";
 // import Blog from "../components/digital-agency/Blog";
 import Partner from "../components/digital-agency/Partner";
-// import Contact from "../components/digital-agency/Contact";
+import Contact from "../components/digital-agency/Contact";
 
 const index = () => (
   <React.Fragment>
@@ -23,6 +23,7 @@ const index = () => (
     <About />
     <Team />
     <Partner />
+    <Contact />
     <Footer />
   </React.Fragment>
 );


### PR DESCRIPTION
# Changes
- [x] Instead of having another form for `Contact`, this is basically the same functionality.
- When a user clicks on the `Contact Us` btn, it will popup with "Compose Email" with the subject title of "website enquiry" in the user's default email provider (in the gif below, I haven't configured my default email provider but you get the point)

- If the client wants to improve organisation of their email inbox, they could then just filter by "website enquiry"
- [x] Refactored from class to functional component


## Screenshots

![Contact](https://user-images.githubusercontent.com/17672458/68113262-7dcf2880-ff47-11e9-8a39-c3305a167524.gif)


## Tested on
- [x] Chrome
- [x] Safari
