### PR TITLE
Fix branding colours

### DIFF
--- a/components/digital-agency/About.css
+++ b/components/digital-agency/About.css
@@ -1,6 +1,6 @@
 :root {
-  --brand-color-red: #fc2847;
-  --brand-color-yellow: #ffd800;
+  --brand-color-red: #DC3F40;
+  --brand-color-yellow: #F3CF07;
   --color-regular: #fff;
 
   --section-heading-ff: sans-serif;

--- a/components/digital-agency/Banner.css
+++ b/components/digital-agency/Banner.css
@@ -1,6 +1,6 @@
 :root {
-  --brand-color-red: #fc2847;
-  --brand-color-yellow: #ffd800;
+  --brand-color-red: #DC3F40;
+  --brand-color-yellow: #F3CF07;
   --color-regular: #fff;
 
   --social-icons: #6084a4;

--- a/components/digital-agency/Contact.css
+++ b/components/digital-agency/Contact.css
@@ -1,5 +1,5 @@
 :root {
-  --brand-color-red: #fc2847;
+  --brand-color-red: #DC3F40;
   --color-regular: #fff;
 
   --contact-btn: var(--brand-color-red);


### PR DESCRIPTION
# Changes
- [x] Used colour picker to determine the hex codes in the client's logo
- [x] Updated all instances of where it's used to have the new hex codes


## Screenshots

<img width="1431" alt="Screen Shot 2019-11-06 at 12 07 36 am" src="https://user-images.githubusercontent.com/17672458/68210430-9e6faf00-0029-11ea-9832-1b6f465cb559.png">


## Tested on
- [x] Chrome
- [x] Safari
